### PR TITLE
imx-gpu-viv: bump version to 6.2.4.p4.8

### DIFF
--- a/package/freescale-imx/imx-gpu-viv/imx-gpu-viv.hash
+++ b/package/freescale-imx/imx-gpu-viv/imx-gpu-viv.hash
@@ -1,5 +1,5 @@
 # Locally calculated
-sha256	b5c94b56a9f7c84aa084603a6ca21b5f3941b400e4f6ee8558b58c9b9f1aab36  imx-gpu-viv-6.4.0.p1.0-aarch32.bin
-sha256	45852a5c3c61a9215a2ffb7387a6e1cce7ddac6f12513fc77459ad7e1f1b3a27  imx-gpu-viv-6.4.0.p1.0-aarch64.bin
+sha256	2804c3d7b8fdd0db6659735cc55b33e7fe749b823ccd9a5ee37b1ccf764ae928  imx-gpu-viv-6.2.4.p4.8-aarch32.bin
+sha256	72c5338003322a4ebf4d28e38f48b3014fcd116bd54d1b42924aa3be32888bd0  imx-gpu-viv-6.2.4.p4.8-aarch64.bin
 sha256	d55f024af2bfff714b90de596f6d0399124b999e8c18a86b13a3b507bae6f561  COPYING
 sha256	9665930f69c0b6f4a4c055d7fe2b8ee563e771efbc83892abb1955e61492cdf7  EULA

--- a/package/freescale-imx/imx-gpu-viv/imx-gpu-viv.mk
+++ b/package/freescale-imx/imx-gpu-viv/imx-gpu-viv.mk
@@ -5,9 +5,9 @@
 ################################################################################
 
 ifeq ($(BR2_aarch64),y)
-IMX_GPU_VIV_VERSION = 6.4.0.p1.0-aarch64
+IMX_GPU_VIV_VERSION = 6.2.4.p4.8-aarch64
 else
-IMX_GPU_VIV_VERSION = 6.4.0.p1.0-aarch32
+IMX_GPU_VIV_VERSION = 6.2.4.p4.8-aarch32
 endif
 IMX_GPU_VIV_SITE = $(FREESCALE_IMX_SITE)
 IMX_GPU_VIV_SOURCE = imx-gpu-viv-$(IMX_GPU_VIV_VERSION).bin


### PR DESCRIPTION
This version works with the 4.14.98_2.3.0 kernel drivers.

Signed-off-by: Michael Fairman <michael.fairman@chargepoint.com>