### PR TITLE
package/psplash: address that psplash might run with no framebuffer

### DIFF
--- a/package/psplash/psplash-start.service
+++ b/package/psplash/psplash-start.service
@@ -3,6 +3,10 @@ Description=Starts Psplash Boot screen
 DefaultDependencies=no
 RequiresMountsFor=/run
 
+# Psplash may be installed on some devices without a framebuffer
+# so ensure it existed before starting
+ConditionPathExists=/dev/fb0
+
 [Service]
 Type=notify
 ExecStart=/usr/bin/psplash -n


### PR DESCRIPTION
Because of the way the code is being bundled, the psplash unit
might run on a headless environment in development or in a fully
assembled fixture for a display.

This just suppresses the somewhat annoying restart loop during
startup:

    [FAILED] Failed to start Starts Psplash Boot screen.
    See 'systemctl status psplash-start.service' for details.

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>