### PR TITLE
package/dhcp: fix dhcp symlink in target/var/lib/dhcp

### DIFF
--- a/package/dhcp/dhcp.mk
+++ b/package/dhcp/dhcp.mk
@@ -59,7 +59,7 @@ define DHCP_INSTALL_CTL_LIBS
 endef
 define DHCP_INSTALL_SERVER
 	mkdir -p $(TARGET_DIR)/var/lib
-	(cd $(TARGET_DIR)/var/lib; ln -snf /tmp dhcp)
+	(cd $(TARGET_DIR)/var/lib; ln -snf ../../tmp dhcp)
 	$(MAKE) -C $(@D)/server DESTDIR=$(TARGET_DIR) install-sbinPROGRAMS
 	$(INSTALL) -m 0644 -D package/dhcp/dhcpd.conf \
 		$(TARGET_DIR)/etc/dhcp/dhcpd.conf
@@ -69,7 +69,7 @@ endif
 ifeq ($(BR2_PACKAGE_DHCP_RELAY),y)
 define DHCP_INSTALL_RELAY
 	mkdir -p $(TARGET_DIR)/var/lib
-	(cd $(TARGET_DIR)/var/lib; ln -snf /tmp dhcp)
+	(cd $(TARGET_DIR)/var/lib; ln -snf ../../tmp dhcp)
 	$(MAKE) -C $(@D)/relay DESTDIR=$(TARGET_DIR) install-sbinPROGRAMS
 endef
 endif
@@ -77,7 +77,7 @@ endif
 ifeq ($(BR2_PACKAGE_DHCP_CLIENT),y)
 define DHCP_INSTALL_CLIENT
 	mkdir -p $(TARGET_DIR)/var/lib
-	(cd $(TARGET_DIR)/var/lib; ln -snf /tmp dhcp)
+	(cd $(TARGET_DIR)/var/lib; ln -snf ../../tmp dhcp)
 	$(MAKE) -C $(@D)/client DESTDIR=$(TARGET_DIR) sbindir=/sbin \
 		install-sbinPROGRAMS
 	$(INSTALL) -m 0644 -D package/dhcp/dhclient.conf \


### PR DESCRIPTION
In a readonly fs configuration the skeleton-init-fs will move
the var directories to the usr/share/factory and the run a command
like this:

   mv $(TARGET_DIR)/var $(TARGET_DIR)/usr/share/factory/var
   mkdir -p $(TARGET_DIR)/var
   for i in $(TARGET_DIR)/usr/share/factory/var/* \
            $(TARGET_DIR)/usr/share/factory/var/lib/* \
            $(TARGET_DIR)/usr/share/factory/var/lib/systemd/*; do

If the symlink is to the /tmp directory the glob compare on the
dhcp link will evaluate and result in an incorrect entry being
created in the resulting tmpfs mount on var.

    L+! /var/lib/dhcp - - - - ../usr/share/factory//var/lib/dhcp

So, make the link relative and the result of the configuration
doesn't get impacted.

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>