### PR TITLE
boot/uboot: add u-boot-dtb.imx.log as target

### DIFF
--- a/boot/uboot/uboot.mk
+++ b/boot/uboot/uboot.mk
@@ -78,6 +78,7 @@ endif
 
 ifeq ($(BR2_TARGET_UBOOT_FORMAT_DTB_IMX),y)
 UBOOT_BINS += u-boot-dtb.imx
+UBOOT_BINS += u-boot-dtb.imx.log
 UBOOT_MAKE_TARGET += u-boot-dtb.imx
 endif
 


### PR DESCRIPTION
The the logfile "u-boot-dtb.imx.log " contains information
required by the Code Signer Tool to correctly sign the
image and perform validation during bootup. This file
is being added to the build so it can be consumed when
a given build is to be signed.

Example contents:

$ cat u-boot-dtb.imx.log
Image Type:   Freescale IMX Boot Image
Image Ver:    2 (i.MX53/6/7 compatible)
Mode:         DCD
Data Size:    495616 Bytes = 484.00 KiB = 0.47 MiB
Load Address: 177ff420
Entry Point:  17800000
HAB Blocks:   177ff400 00000000 00074c00
DCD Blocks:   00910000 0000002c 00000300