### PR TITLE
targets: imx boot splash screens (psplash service)

### DIFF
--- a/package/psplash/psplash-start.service
+++ b/package/psplash/psplash-start.service
@@ -10,6 +10,7 @@ ConditionPathExists=/dev/fb0
 [Service]
 Type=notify
 ExecStart=/usr/bin/psplash -n
+RemainAfterExit=yes
 
 [Install]
 WantedBy=sysinit.target

--- a/package/psplash/psplash-systemd.service
+++ b/package/psplash/psplash-systemd.service
@@ -7,6 +7,7 @@ RequiresMountsFor=/run
 
 [Service]
 ExecStart=/usr/bin/psplash-systemd
+RemainAfterExit=yes
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
Recent systemd versions require RemainAfterExit for interdependent services to avoid
restarting the lower dependency, even if it's not marked for restart on exit.

From Yocto commit:
https://github.com/kraj/poky/commit/ce987c6ae867eb9b0850445d496fb01c5c6709a

JIRA PLAT-1133