### PR TITLE
Packages: sox makefile update to install header and .so file

### DIFF
--- a/package/sox/sox.mk
+++ b/package/sox/sox.mk
@@ -12,6 +12,7 @@ SOX_LICENSE = GPL-2.0+ (sox binary), LGPL-2.1+ (libraries)
 SOX_LICENSE_FILES = LICENSE.GPL LICENSE.LGPL
 SOX_CPE_ID_VENDOR = sound_exchange_project
 SOX_CPE_ID_PRODUCT = sound_exchange
+SOX_INSTALL_STAGING = YES
 # From git and we're patching configure.ac
 SOX_AUTORECONF = YES
 SOX_AUTORECONF_OPTS = --include=$(HOST_DIR)/share/autoconf-archive


### PR DESCRIPTION
This patch installs the sox header file and shared library files to the staging folder during the build process. With this, the header and shared library files can be included.

JIRA : https://chargepoint.atlassian.net/browse/PLAT-1231