### PR TITLE
support/misc: update the Vagrantfile to use the git checkout

### DIFF
--- a/support/misc/Vagrantfile
+++ b/support/misc/Vagrantfile
@@ -8,11 +8,20 @@
 RELEASE='2020.02'
 
 ### Change here for more memory/cores ###
-VM_MEMORY=2048
-VM_CORES=1
+VM_MEMORY=5144
+VM_CORES=4
 
 Vagrant.configure('2') do |config|
+	# ssh keys
+	config.ssh.forward_agent = true
+	config.ssh.forward_x11 = true
+
+	# Define the Virtual VM
 	config.vm.box = 'ubuntu/bionic64'
+	config.vm.synced_folder ".", "/vagrant", disabled: true
+	vagrant_root = File.join(File.dirname(__FILE__), "..", "..")
+	config.vm.provision "shell", inline: "mkdir -p /home/vagrant/buildroot"
+	config.vm.synced_folder vagrant_root, "/home/vagrant/buildroot"
 
 	config.vm.provider :vmware_fusion do |v, override|
 		v.vmx['memsize'] = VM_MEMORY
@@ -51,10 +60,5 @@ Vagrant.configure('2') do |config|
 		apt-get -q -y autoremove
 		apt-get -q -y clean
 		update-locale LC_ALL=C"
-
-	config.vm.provision 'shell', privileged: false, inline:
-		"echo 'Downloading and extracting buildroot #{RELEASE}'
-		wget -q -c http://buildroot.org/downloads/buildroot-#{RELEASE}.tar.gz
-		tar axf buildroot-#{RELEASE}.tar.gz"
 
 end


### PR DESCRIPTION
The default vagrant downloads a buildroot tarball and builds that,
but for testing it is a bit more convenient to just use the shared
directory across the vagrant box against the checked out buildroot

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>