### PR TITLE
package/unzip: configure with LARGE_FILE_SUPPORT by default

### DIFF
--- a/package/unzip/unzip.mk
+++ b/package/unzip/unzip.mk
@@ -26,4 +26,18 @@ UNZIP_IGNORE_CVES = \
 	CVE-2018-1000035 \
 	CVE-2019-13232
 
+# unzip already defines _LARGEFILE_SOURCE and _LARGEFILE64_SOURCE when
+# necessary, redefining it on the command line causes some warnings.
+UNZIP_TARGET_CFLAGS = \
+	$(filter-out -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE,$(TARGET_CFLAGS))
+
+# unzip already defines _LARGEFILE_SOURCE and _LARGEFILE64_SOURCE when
+# necessary, redefining it on the command line causes some warnings.
+UNZIP_TARGET_CXXFLAGS = \
+	$(filter-out -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE,$(TARGET_CXXFLAGS))
+
+UNZIP_CONF_OPTS += \
+	-DCMAKE_C_FLAGS="$(UNZIP_TARGET_CFLAGS) -DLARGE_FILE_SUPPORT" \
+	-DCMAKE_CXX_FLAGS="$(UNZIP_TARGET_CXXFLAGS) -DLARGE_FILE_SUPPORT"
+
 $(eval $(cmake-package))


### PR DESCRIPTION
Buildroot always enable largefile support in the toolchains, and
thus the associated definitions are always on. This leads to a
problem in the unzip that on a 32-bit arch with these flags being
passed in

   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64

But, the LARGE_FILE_SUPPORT not being defined will cause a size
mismatch on the comparison of the zipfiles.

    $ unzip test.zip
    Archive: test.zip
    error: invalid zip file with overlapped components (possible zip bomb)

Simple solution is just enable LARGE_FILE_SUPPORT in cmake to get
an expected extraction.

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>

[PLAT-1632]

[PLAT-1632]: https://chargepoint.atlassian.net/browse/PLAT-1632