### PR TITLE
package/libwebsockets: disable LWS_WITH_EXTERNAL_POLL

### DIFF
--- a/package/libwebsockets/libwebsockets.mk
+++ b/package/libwebsockets/libwebsockets.mk
@@ -15,9 +15,6 @@ LIBWEBSOCKETS_CONF_OPTS = \
 	-DLWS_IPV6=ON \
 	-DLWS_UNIX_SOCK=ON \
 	-DLWS_WITHOUT_EXTENSIONS=OFF
-LIBWEBSOCKETS_CONF_OPTS += \
-	-DLWS_WITH_EXTERNAL_POLL=ON \
-	-DDISABLE_WERROR=ON
 
 # If LWS_MAX_SMP=1, then there is no code related to pthreads compiled
 # in the library. If unset, LWS_MAX_SMP defaults to 32 and a small


### PR DESCRIPTION
LWS_WITH_EXTERNAL_POLL was set to support legacy code that relied on external event loop support. This code is no longer present.

Signed-off-by: David Leeds <david.leeds@chargepoint.com>