### PR TITLE
package/psplash: repair support for multiline messages on bootsplash

### DIFF
--- a/package/psplash/0001-psplash_multiline_msg.patch
+++ b/package/psplash/0001-psplash_multiline_msg.patch
@@ -1,0 +1,21 @@
+diff -Naurp a/psplash-fb.c b/psplash-fb.c
+--- a/psplash-fb.c	2020-08-12 10:44:48.000000000 -0700
++++ b/psplash-fb.c	2021-06-29 21:09:52.885448257 -0700
+@@ -553,7 +553,7 @@ psplash_fb_text_size (int
+   mbtowc (0, 0, 0);
+   for (; (k = mbtowc (&wc, c, n)) > 0; c += k, n -= k)
+     {
+-      if (*c == '\n')
++      if (*c == '\v')
+ 	{
+ 	  if (w > mw)
+ 	    mw = w;
+@@ -592,7 +592,7 @@ psplash_fb_draw_text (PSplashFB
+     {
+       u_int32_t *glyph = NULL;
+ 
+-      if (*c == '\n')
++      if (*c == '\v')
+ 	{
+ 	  dy += h;
+ 	  dx  = 0;


### PR DESCRIPTION
In order to display multiline messages on boot, such as hostname and
version, psplash has to be patched to allow a new line separator, as
newline is used to tokenize commands.  Added support for vertical-tabs.

Signed-off-by: Matthew Hungerford <mhungerford@gmail.com>