### PR TITLE
systemd:  set options for resolver mode

### DIFF
--- a/package/systemd/Config.in
+++ b/package/systemd/Config.in
@@ -402,6 +402,39 @@ config BR2_PACKAGE_SYSTEMD_RESOLVED
 
 	  http://www.freedesktop.org/software/systemd/man/systemd-resolved.html
 
+if BR2_PACKAGE_SYSTEMD_RESOLVED
+
+choice
+	prompt "systemd-resolved mode"
+	default BR2_PACKAGE_SYSTEMD_RESOLVED_MODE_COMPAT
+	help
+	  systemd-resolved default operating mode
+
+config BR2_PACKAGE_SYSTEMD_RESOLVED_MODE_COMPAT
+	bool "compat mode (resolve.conf managed by service)"
+	help
+	  systemd-resolved has 4 operating modes. In the buildroot default
+	  mode a hardlink is mainted where upstream dns servers are written
+	  to /run/systemd/resolve/resolv.conf and hard-linked to
+	  /etc/resolv.conf. This has no benefits of cache or other settings.
+
+	  https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html#/etc/resolv.conf
+
+config BR2_PACKAGE_SYSTEMD_RESOLVED_MODE_STUB
+	bool "stub mode (reslove.conf pointed at 127.0.0.53)"
+	help
+	  systemd-resolved has 4 operating modes. In stub resovler mode
+	  systemd-resolved listens on local 127.0.0.53:53 and will perform
+	  advanced functions like RR caching, advanced routing and so on.
+
+	  In this mode the resolver hard link is set from /run/systemd/resolve/stub-resolv.conf -> /etc/resolv.conf
+
+	  https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html#/etc/resolv.conf
+
+endchoice
+ 
+endif
+
 config BR2_PACKAGE_SYSTEMD_RFKILL
 	bool "enable rfkill tools"
 	help

--- a/package/systemd/systemd.mk
+++ b/package/systemd/systemd.mk
@@ -440,10 +440,18 @@ SYSTEMD_CONF_OPTS += -Dnetworkd=false
 endif
 
 ifeq ($(BR2_PACKAGE_SYSTEMD_RESOLVED),y)
-define SYSTEMD_INSTALL_RESOLVCONF_HOOK
+ifeq ($(BR2_PACKAGE_SYSTEMD_RESOLVED_MODE_COMPAT),y)
+define SYSTEMD_INSTALL_RESOLVCRNF_HOOK
 	ln -sf ../run/systemd/resolve/resolv.conf \
 		$(TARGET_DIR)/etc/resolv.conf
 endef
+endif
+ifeq ($(BR2_PACKAGE_SYSTEMD_RESOLVED_MODE_STUB),y)
+define SYSTEMD_INSTALL_RESOLVCRNF_HOOK
+	ln -sf ../run/systemd/resolve/stub-resolv.conf \
+		$(TARGET_DIR)/etc/resolv.conf
+endef
+endif
 SYSTEMD_CONF_OPTS += -Dnss-resolve=true -Dresolve=true
 SYSTEMD_RESOLVED_USER = systemd-resolve -1 systemd-resolve -1 * - - - systemd Resolver
 else


### PR DESCRIPTION
systemd-resolved has a single hardlink set to compat mode which does not allow
for features such as DNS caching and other fun things.  This choice allows the
hard-link to be changed between a couple of operating modes, the default
(compat) and the more useful variant (stub, systemd recommended default) which
allows the resolver to act as a caching daemon.

Signed-off-by: Jeff Hart <jeffrey.hart@chargepoint.com>