### PR TITLE
ModemManager: enable AT interface with bool flag

### DIFF
--- a/package/modem-manager/Config.in
+++ b/package/modem-manager/Config.in
@@ -25,6 +25,14 @@ config BR2_PACKAGE_MODEM_MANAGER_LIBQMI
 	select BR2_PACKAGE_LIBQMI
 	help
 	  This option enables support for QMI protocol
+
+config BR2_PACKAGE_MODEM_MANAGER_AT_INTERFACE
+	bool "Always enable AT commands"
+	default n
+	help
+	  This option enables the AT command interface
+	  without --debug flag being required
+
 endif
 
 comment "modemmanager needs a toolchain w/ wchar, threads"

--- a/package/modem-manager/modem-manager.mk
+++ b/package/modem-manager/modem-manager.mk
@@ -41,6 +41,10 @@ else
 MODEM_MANAGER_CONF_OPTS += --disable-introspection
 endif
 
+ifeq ($(BR2_PACKAGE_MODEM_MANAGER_AT_INTERFACE),y)
+MODEM_MANAGER_CONF_OPTS += --with-at-command-via-dbus
+endif
+
 define MODEM_MANAGER_INSTALL_INIT_SYSV
 	$(INSTALL) -m 0755 -D package/modem-manager/S44modem-manager \
 		$(TARGET_DIR)/etc/init.d/S44modem-manager


### PR DESCRIPTION
ModemManager only allows AT commands to be sent over dbus if the --debug
flag is specified.  Add a config option to allow setting the
compile-time flag to allow the AT command interface outside of debug-only mode.