### PR TITLE
package/dbus: bump to version 1.13.20

### DIFF
--- a/package/dbus/dbus.hash
+++ b/package/dbus/dbus.hash
@@ -1,7 +1,3 @@
-# Locally calculated after checking pgp signature
-# https://dbus.freedesktop.org/releases/dbus/dbus-1.12.20.tar.gz.asc
-# using key 36EC5A6448A4F5EF79BEFE98E05AE1478F814C4F
-sha256  f77620140ecb4cdc67f37fb444f8a6bea70b5b6461f12f1cbe2cec60fa7de5fe  dbus-1.12.20.tar.gz
-
-# Locally calculated
+# Locally calculated:
+sha256  a9c4b7bad9f49ffa4f199a12aedcdad5d5dcef875d794829fd1378153e072963  dbus-1.13.20.tar.xz
 sha256  0e46f54efb12d04ab5c33713bacd0e140c9a35b57ae29e03c853203266e8f3a1  COPYING

--- a/package/dbus/dbus.mk
+++ b/package/dbus/dbus.mk
@@ -4,7 +4,8 @@
 #
 ################################################################################
 
-DBUS_VERSION = 1.12.20
+DBUS_VERSION = 1.13.20
+DBUS_SOURCE = dbus-$(DBUS_VERSION).tar.xz
 DBUS_SITE = https://dbus.freedesktop.org/releases/dbus
 DBUS_LICENSE = AFL-2.1 or GPL-2.0+ (library, tools), GPL-2.0+ (tools)
 DBUS_LICENSE_FILES = COPYING


### PR DESCRIPTION
Bump `dbus` package from 1.12.20 to 1.13.20. This includes a host of bug fixes and improvements, but the relevant change, is `dbus-send` gets a `--sender` option that enables it to send signals that D-Bus proxies won't filter out.
