### PR TITLE
package/cmake: upgrade to 3.16.9 and enable openssl

### DIFF
--- a/package/cmake/cmake.hash
+++ b/package/cmake/cmake.hash
@@ -1,5 +1,5 @@
-# From https://cmake.org/files/v3.15/cmake-3.15.5-SHA-256.txt
-sha256 fbdd7cef15c0ced06bb13024bfda0ecc0dedbcaaaa6b8a5d368c75255243beb4  cmake-3.15.5.tar.gz
+# From https://cmake.org/files/v3.16/cmake-3.16.9-SHA-256.txt
+sha256  1708361827a5a0de37d55f5c9698004c035abb1de6120a376d5d59a81630191f  cmake-3.16.9.tar.gz
 
 # Locally calculated
-sha256 dc628fb936a5d229296d42083f9a8218aa32204c016919e784404c9ec58776e9  Copyright.txt
+sha256  dc628fb936a5d229296d42083f9a8218aa32204c016919e784404c9ec58776e9  Copyright.txt

--- a/package/cmake/cmake.mk
+++ b/package/cmake/cmake.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-CMAKE_VERSION_MAJOR = 3.15
-CMAKE_VERSION = $(CMAKE_VERSION_MAJOR).5
+CMAKE_VERSION_MAJOR = 3.16
+CMAKE_VERSION = $(CMAKE_VERSION_MAJOR).9
 CMAKE_SITE = https://cmake.org/files/v$(CMAKE_VERSION_MAJOR)
 CMAKE_LICENSE = BSD-3-Clause
 CMAKE_LICENSE_FILES = Copyright.txt

--- a/package/cmake/cmake.mk
+++ b/package/cmake/cmake.mk
@@ -20,12 +20,13 @@ CMAKE_IGNORE_CVES = CVE-2016-10642
 #   host-cmake package, then the (target-)cmake package can be built
 #   using the cmake infrastructure;
 # * CMake bundles its dependencies within its sources. This is the
-#   reason why the host-cmake package has no dependencies:, whereas
+#   reason why the host-cmake package has few dependencies:, whereas
 #   the (target-)cmake package has a lot of dependencies, using only
 #   the system-wide libraries instead of rebuilding and statically
 #   linking with the ones bundled into the CMake sources.
 
 CMAKE_DEPENDENCIES = zlib jsoncpp libcurl libarchive expat bzip2 xz libuv rhash
+HOST_CMAKE_DEPENDENCIES = host-openssl
 
 CMAKE_CONF_OPTS = \
 	-DKWSYS_LFS_WORKS=TRUE \
@@ -49,7 +50,6 @@ define HOST_CMAKE_CONFIGURE_CMDS
 			-DCMAKE_C_FLAGS="$(HOST_CMAKE_CFLAGS)" \
 			-DCMAKE_CXX_FLAGS="$(HOST_CMAKE_CXXFLAGS)" \
 			-DCMAKE_EXE_LINKER_FLAGS="$(HOST_LDFLAGS)" \
-			-DCMAKE_USE_OPENSSL:BOOL=OFF \
 			-DBUILD_CursesDialog=OFF \
 	)
 endef


### PR DESCRIPTION
In order to build tensorflow lite 2.6.0 using the cmake build system (the make build sytem is being deprecated), the cmake package included in buildroot needs to be updated; buildroot upstream has already upgraded buildroot to 3.16.9 which works well for tensorflow lite builds and seems fine for all other cmake builds we use (like emb-core).

Another thing tensorflow lite needs to build correctly is OpenSSL support has part of cmake since it uses `FetchContent` in order to fetch dependent packages (which in turn needs cmake itself to support HTTPS). It seems this was originally disabled in buildroot to avoid leaking dependencies to the host systems but from what I can tell, that no longer an issue.

(Getting a bit of a jump start on tensorflow lite integration as this is required but independent of Qt)