### PR TITLE
package/systemd: add configuration support for SysV compat

### DIFF
--- a/package/systemd/Config.in
+++ b/package/systemd/Config.in
@@ -520,4 +520,13 @@ config BR2_PACKAGE_SYSTEMD_VCONSOLE
 
 	  http://www.freedesktop.org/software/systemd/man/systemd-vconsole-setup.service.html
 
+config BR2_PACKAGE_SYSTEMD_SYSV_COMPAT
+	bool "enable sysvinit/sysvrcd compat"
+	help
+	  systemd-sysv-generator creates a wrapper service for sysv
+	  init scripts in /etc/init.d/* at boot and when configuration
+	  of the system manager is reloaded
+
+	  https://www.freedesktop.org/software/systemd/man/systemd-sysv-generator.html
+
 endif

--- a/package/systemd/systemd.mk
+++ b/package/systemd/systemd.mk
@@ -44,8 +44,6 @@ SYSTEMD_CONF_OPTS += \
 	-Dsulogin-path=/usr/sbin/sulogin \
 	-Dsystem-gid-max=999 \
 	-Dsystem-uid-max=999 \
-	-Dsysvinit-path= \
-	-Dsysvrcnd-path= \
 	-Dtelinit-path= \
 	-Dtests=false \
 	-Dumount-path=/usr/bin/umount \
@@ -422,6 +420,12 @@ ifeq ($(BR2_PACKAGE_SYSTEMD_PORTABLED),y)
 SYSTEMD_CONF_OPTS += -Dportabled=true
 else
 SYSTEMD_CONF_OPTS += -Dportabled=false
+endif
+
+ifeq ($(BR2_PACKAGE_SYSTEMD_SYSV_COMPAT),y)
+SYSTEMD_CONF_OPTS += -Dsysvinit-path='/etc/init.d' -Dsysvrcnd-path='/etc'
+else
+SYSTEMD_CONF_OPTS += -Dsysvinit-path='' -Dsysvrcnd-path=''
 endif
 
 ifeq ($(BR2_PACKAGE_SYSTEMD_NETWORKD),y)


### PR DESCRIPTION
The compatible flags for the init and rc directories are disabled
by default, so allow a configuration option to set the expected
paths to /etc/init.d and /etc respectively.

This allows a hybrid systemd approach as needed for startup

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>