### PR TITLE
libwebsockets: bump to v4.3.0

### DIFF
--- a/package/libwebsockets/libwebsockets.hash
+++ b/package/libwebsockets/libwebsockets.hash
@@ -1,3 +1,3 @@
 # Locally computed:
-sha256  a57e9a4765dbcd4d880feba8089b43ed69995eaf10d5d61a07981d9ddd975f40  libwebsockets-4.2.0.tar.gz
+sha256  ceef46e3bffb368efe4959202f128fd93d74e10cd2e6c3ac289a33b075645c3b  libwebsockets-4.3.0.tar.gz
 sha256  5756db345eb9c21cb06dd7cb69c38ec234657a233f9a186b4f5fa453681bd394  LICENSE

--- a/package/libwebsockets/libwebsockets.mk
+++ b/package/libwebsockets/libwebsockets.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBWEBSOCKETS_VERSION = 4.2.0
+LIBWEBSOCKETS_VERSION = 4.3.0
 LIBWEBSOCKETS_SITE = $(call github,warmcat,libwebsockets,v$(LIBWEBSOCKETS_VERSION))
 LIBWEBSOCKETS_LICENSE = MIT with exceptions
 LIBWEBSOCKETS_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Bump libwebsockets to v4.3.0 to pull in IPv6 fixes.

Signed-off-by: Jeffrey Hart <jeffrey.hart@chargepoint.com>