### PR TITLE
package/imx-seco: add choices for imx8 socs

### DIFF
--- a/package/freescale-imx/imx-seco/Config.in
+++ b/package/freescale-imx/imx-seco/Config.in
@@ -7,3 +7,47 @@ config BR2_PACKAGE_IMX_SECO
 
 	  This library is provided by Freescale as-is and doesn't have
 	  an upstream.
+
+if BR2_PACKAGE_IMX_SECO
+
+choice
+	prompt "i.MX Seco Firmware Release"
+	default BR2_PACKAGE_IMX_SECO_MX8QMB0 if BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8
+	default BR2_PACKAGE_IMX_SECO_MX8QXC0 if BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8X
+	help
+	  Select the appropriate ahab container image to install
+	  to match the iMX asics revision.
+
+	  Note - mismatches result in a failure to boot
+
+config BR2_PACKAGE_IMX_SECO_MX8DXLA0
+	bool "imx-seco-mx8dxla0"
+	depends on BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8X
+
+config BR2_PACKAGE_IMX_SECO_MX8DXLA1
+	bool "imx-seco-mx8dxla1"
+	depends on BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8X
+
+config BR2_PACKAGE_IMX_SECO_MX8QMB0
+	bool "imx-seco-mx8qmb0"
+	depends on BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8
+
+config BR2_PACKAGE_IMX_SECO_MX8QXB0
+	bool "imx-seco-mx8qxb0"
+	depends on BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8X
+
+config BR2_PACKAGE_IMX_SECO_MX8QXC0
+	bool "imx-seco-mx8qxc0"
+	depends on BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8X
+
+endchoice
+
+config BR2_PACKAGE_IMX_SECO_AHAB_CONTAINER_IMAGE
+	string
+	default "mx8dxla0-ahab-container.img" if BR2_PACKAGE_IMX_SECO_MX8DXLA0
+	default "mx8dxla1-ahab-container.img" if BR2_PACKAGE_IMX_SECO_MX8DXLA1
+	default "mx8qmb0-ahab-container.img" if BR2_PACKAGE_IMX_SECO_MX8QMB0
+	default "mx8qxb0-ahab-container.img" if BR2_PACKAGE_IMX_SECO_MX8QXB0
+	default "mx8qxc0-ahab-container.img" if BR2_PACKAGE_IMX_SECO_MX8QXC0
+
+endif

--- a/package/freescale-imx/imx-seco/imx-seco.mk
+++ b/package/freescale-imx/imx-seco/imx-seco.mk
@@ -20,16 +20,11 @@ IMX_SECO_INSTALL_IMAGES = YES
 
 # SECO firmware is needed when generating imx8-boot-sd.bin which
 # is done in post-image script.
-ifeq ($(BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8X),y)
+IMX_SECO_AHAB_CONTAINER_IMAGE = $(call qstrip,$(BR2_PACKAGE_IMX_SECO_AHAB_CONTAINER_IMAGE))
+
 define IMX_SECO_INSTALL_IMAGES_CMDS
-	cp $(@D)/firmware/seco/mx8qxc0-ahab-container.img \
+	cp $(@D)/firmware/seco/$(IMX_SECO_AHAB_CONTAINER_IMAGE) \
 		$(BINARIES_DIR)/ahab-container.img
 endef
-else ifeq ($(BR2_PACKAGE_FREESCALE_IMX_PLATFORM_IMX8),y)
-define IMX_SECO_INSTALL_IMAGES_CMDS
-	cp $(@D)/firmware/seco/mx8qmb0-ahab-container.img \
-		$(BINARIES_DIR)/ahab-container.img
-endef
-endif
 
 $(eval $(generic-package))


### PR DESCRIPTION
Changes added to select ahab container image
for different imx8 socs including imx8dxl.

Signed-off-by: Aswath Gajendran <aswath.gajendran@chargepoint.com>