### PR TITLE
chrony: use -s option to set time from RTC on boot

### DIFF
--- a/package/chrony/chrony.service
+++ b/package/chrony/chrony.service
@@ -8,7 +8,7 @@ Conflicts=systemd-timesyncd.service
 # correct time to work, but we likely won't acquire that without NTP. Let's
 # break this chicken-and-egg cycle here.
 Environment=SYSTEMD_NSS_RESOLVE_VALIDATE=0
-ExecStart=/usr/sbin/chronyd -n
+ExecStart=/usr/sbin/chronyd -n -s
 Restart=always
 
 [Install]


### PR DESCRIPTION
As suggested by @jhart-cpi '-s' option is used

PLAT-4389

Log
root@mcb285731:~# systemctl status chrony.service --no-pager -l
? chrony.service - Chrony Network Time Daemon
     Loaded: loaded (/usr/lib/systemd/system/chrony.service; enabled; vendor preset: enabled)
     Active: active (running) since Mon 2022-04-11 15:25:24 UTC; 1min 38s ago
   Main PID: 765 (chronyd)
      Tasks: 1 (limit: 1157)
     Memory: 1.2M
     CGroup: /system.slice/chrony.service
             mq765 /usr/sbin/chronyd -n -s

Apr 11 15:25:24 mcb285731 systemd[1]: Started Chrony Network Time Daemon.
Apr 11 15:25:24 mcb285731 chronyd[765]: chronyd version 4.0 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP -SCFILTER -SIGND +ASYNCDNS +NTS +SECHASH +IPV6 -DEBUG)