### PR TITLE
package/psplash: add the start order for the psplash systemd

### DIFF
--- a/package/psplash/psplash-systemd.service
+++ b/package/psplash/psplash-systemd.service
@@ -3,6 +3,7 @@ Description=Start psplash-systemd progress communication helper
 DefaultDependencies=no
 After=systemd-start.service
 Requires=psplash-start.service
+After=psplash-start.service
 RequiresMountsFor=/run
 
 [Service]


### PR DESCRIPTION
The fifo is created from psplash-start and so only having a Requires lists the dependency on
psplash-start but not that this service needs to come after the start.

  Requires=

    Similar to Wants=, but declares a stronger requirement dependency.
    Dependencies of this type may also be configured by adding a symlink
    to a .requires/ directory accompanying the unit file.

    If this unit gets activated, the units listed will be activated as
    well. If one of the other units fails to activate, and an ordering
    dependency After= on the failing unit is set, this unit will not be
    started. Besides, with or without specifying After=, this unit will
    be stopped (or restarted) if one of the other units is explicitly
    stopped (or restarted).

    Often, it is a better choice to use Wants= instead of Requires= in
    order to achieve a system that is more robust when dealing with
    failing services.

    Note that this dependency type does not imply that the other unit
    always has to be in active state when this unit is running.
    Specifically: failing condition checks (such as ConditionPathExists=,
    ConditionPathIsSymbolicLink=, … — see below) do not cause the start
    job of a unit with a Requires= dependency on it to fail. Also, some
    unit types may deactivate on their own (for example, a service process
    may decide to exit cleanly, or a device may be unplugged by the user),
    which is not propagated to units having a Requires= dependency. Use
    the BindsTo= dependency type together with After= to ensure that a
    unit may never be in active state without a specific other unit also
    in active state (see below).

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>