### PR TITLE
libv4l: revert to previous version 1.20.0 due to camera subdev issue.

### DIFF
--- a/package/libv4l/Config.in
+++ b/package/libv4l/Config.in
@@ -20,7 +20,6 @@ comment "libv4l JPEG support not enabled"
 
 config BR2_PACKAGE_LIBV4L_UTILS
 	bool "v4l-utils tools"
-	depends on BR2_TOOLCHAIN_GCC_AT_LEAST_4_8 # C++11
 	help
 	  v4l-utils is a collection of various video4linux and DVB
 	  utilities.
@@ -35,9 +34,6 @@ config BR2_PACKAGE_LIBV4L_UTILS
 	  - v4l2-sysfs-path
 	  - rds-ctl
 	  - qv4l2 (if Qt is enabled)
-
-comment "v4l-utils tools needs a toolchain w/ C++11"
-	depends on !BR2_TOOLCHAIN_GCC_AT_LEAST_4_8
 
 endif
 

--- a/package/libv4l/libv4l.hash
+++ b/package/libv4l/libv4l.hash
@@ -1,7 +1,7 @@
 # Locally calculated after checking signature
 # https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2.asc
 # with key 05D0169C26E41593418129DF199A64FADFB500FF
-sha256  65c6fbe830a44ca105c443b027182c1b2c9053a91d1e72ad849dfab388b94e31  v4l-utils-1.22.1.tar.bz2
+sha256 956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7  v4l-utils-1.20.0.tar.bz2
 
 # Locally calculated
 sha256  391e4da1c54a422a78d83be7bf84b2dfb8bacdd8ad256fa4374e128655584a8a  COPYING

--- a/package/libv4l/libv4l.mk
+++ b/package/libv4l/libv4l.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBV4L_VERSION = 1.22.1
+LIBV4L_VERSION = 1.20.0
 LIBV4L_SOURCE = v4l-utils-$(LIBV4L_VERSION).tar.bz2
 LIBV4L_SITE = https://linuxtv.org/downloads/v4l-utils
 LIBV4L_INSTALL_STAGING = YES
@@ -28,6 +28,7 @@ endif
 
 ifeq ($(BR2_PACKAGE_ARGP_STANDALONE),y)
 LIBV4L_DEPENDENCIES += argp-standalone
+LIBV4L_LIBS += -largp
 endif
 
 LIBV4L_DEPENDENCIES += $(if $(BR2_PACKAGE_LIBICONV),libiconv)
@@ -44,10 +45,8 @@ LIBV4L_DEPENDENCIES += libgl
 endif
 
 ifeq ($(BR2_PACKAGE_HAS_UDEV),y)
-LIBV4L_CONF_OPTS += --with-libudev --with-udevdir=/usr/lib/udev
+LIBV4L_CONF_OPTS += --with-udevdir=/usr/lib/udev
 LIBV4L_DEPENDENCIES += udev
-else
-LIBV4L_CONF_OPTS += --without-libudev
 endif
 
 ifeq ($(BR2_PACKAGE_LIBGLU),y)
@@ -57,9 +56,6 @@ endif
 ifeq ($(BR2_PACKAGE_LIBV4L_UTILS),y)
 LIBV4L_CONF_OPTS += --enable-v4l-utils
 LIBV4L_DEPENDENCIES += $(TARGET_NLS_DEPENDENCIES)
-
-# v4l2-ctl needs c++11, use gnu++11 for typeof support
-LIBV4L_CONF_ENV += CXXFLAGS="$(TARGET_CXXFLAGS) -std=gnu++11"
 
 # IR BPF decoder support needs toolchain with linux-headers >= 3.18
 # libelf and clang support
@@ -73,6 +69,8 @@ LIBV4L_CONF_ENV += \
 	ac_cv_prog_MOC=$(HOST_DIR)/bin/moc \
 	ac_cv_prog_RCC=$(HOST_DIR)/bin/rcc \
 	ac_cv_prog_UIC=$(HOST_DIR)/bin/uic
+# qt5 needs c++11 (since qt-5.7)
+LIBV4L_CONF_ENV += CXXFLAGS="$(TARGET_CXXFLAGS) -std=c++11"
 else
 LIBV4L_CONF_OPTS += --disable-qv4l2
 endif
@@ -83,5 +81,7 @@ endif
 ifeq ($(BR2_PACKAGE_SDL2_IMAGE),y)
 LIBV4L_DEPENDENCIES += sdl2_image
 endif
+
+LIBV4L_CONF_ENV += LIBS="$(LIBV4L_LIBS)"
 
 $(eval $(autotools-package))


### PR DESCRIPTION
Latest version of v4l2-ctl included in libv4l 1.22 causes the following error:
VIDIOC_SUBDEV_QUERYCAP: failed: Inappropriate ioctl for device 
Previous 1.20 version does not.  
This seems to be related to kernel changes around subdev interface, so may be fixed when kernel is updated.

Signed-off-by: mhungerford-cpi <matt.hungerford@chargepoint.com>